### PR TITLE
moving to .net 10 exclusively.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- build info-->
     <!-- ============================================================================ -->
     <!-- Set the target frameworks for all projects -->
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <!-- Set the configuration to Debug by default -->
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <!-- Enable nullable reference types -->
@@ -20,7 +20,7 @@
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>syrx;data access;orm;micro-orm</PackageTags>
-    <PackageReleaseNotes>Last release on .NET8.0 exclusively. Next release will include .NET9.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>Version 3.0.0 exclusively targets .NET 10.0, removing support for .NET 8.0 and .NET 9.0. This release includes comprehensive documentation updates, readme files added to all packages, updated package references, and improved project structure.</PackageReleaseNotes>
     <!-- ============================================================================ -->
     <!-- organization info -->
     <!-- ============================================================================ -->


### PR DESCRIPTION

This pull request updates the project to exclusively target .NET 10.0, removing previous support for .NET 8.0 and .NET 9.0. The release notes have also been updated to reflect this major change and to highlight additional improvements such as documentation updates, new readme files, updated package references, and an improved project structure.

.NET target framework update:
* Changed the `TargetFrameworks` property in `Directory.Build.props` to only include `net10.0`, dropping support for `net8.0` and `net9.0`.

Release notes and documentation:
* Updated the `PackageReleaseNotes` in `Directory.Build.props` to communicate the exclusive targeting of .NET 10.0 and summarize other improvements such as documentation updates, new readme files, updated package references, and better project structure.