### PR TITLE
moving to .net 10 exclusively.

### DIFF
--- a/.docs/Syrx/readme.md
+++ b/.docs/Syrx/readme.md
@@ -9,7 +9,7 @@ Syrx places emphasis on:
 * _Speed_: Performance is a feature. Syrx inherits its speed from Dapper.
 * _Flexibilty_: Your choice of database technology should be as easy to change as any other component in your solution. 
 * _Testability_: We believe strongly in the power of testing at all levels of your applications. Syrx is fully testable and fully tested.
-* _Extensibility_: Syrx is granular and componentised, allowing you two swap out components for your own needs. 
+* _Extensibility_: Syrx is granular and componentised, allowing you to swap out components for your own needs. 
 * _Readability_: Syrx aims to keep the intent of your code clear and concise. 
 
 ## Quick Look
@@ -25,7 +25,7 @@ The central construct in Syrx is the ICommander interface. This interface expose
 Syrx allows you to retrieve both primitive and complex types from the underlying database very simply. 
 There are no special attribute declarations, no special inheritance structures. Very often, complex 
 types can be retrieved with a single line of code. More complex types can be composed using predicates. 
-Syrx supports Func<> predicate with up to 16 inputs for composition. 
+Syrx supports `Func<>` predicate with up to 16 inputs for composition. 
 
 
 _Example_
@@ -159,7 +159,7 @@ namespace Syrx.Samples
 
 ## Support Runtimes and Vendors
 
-Syrx is cross-platform and currently supports .NET 8.0 and later versions.
+Syrx is cross-platform and currently supports .NET 10.0.
 
 Syrx currently supports the following RDBMS vendors, and this list is growing. Implementing support for a new ADO.NET provider is easily accomplished:
 

--- a/.docs/quick-start.md
+++ b/.docs/quick-start.md
@@ -14,7 +14,7 @@ Get up and running with Syrx in minutes. This guide will walk you through creati
 
 ## Prerequisites
 
-- .NET 8.0 or later
+- .NET 10.0
 - SQL Server, MySQL, PostgreSQL, or Oracle database
 - Visual Studio 2022 or Visual Studio Code
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -449,7 +449,7 @@ public async Task<User> GetUserByIdAsync(int id)
 
 ## Version and Compatibility
 
-- **Target Framework**: .NET 8.0+
+- **Target Framework**: .NET 10.0+
 - **Database Support**: SQL Server, MySQL, PostgreSQL, Oracle
 - **Dependencies**: Minimal dependencies (primarily Dapper and Microsoft.Extensions.*)
 - **Breaking Changes**: Follow semantic versioning principles

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ namespace Syrx.Samples
 
 ## Support Runtimes and Vendors
 
-Syrx is cross-platform and currently supports **.NET 8.0** and **.NET 9.0**.
+Syrx is cross-platform and currently supports **.NET 10.0**.
 
 Syrx currently supports the following RDBMS vendors, and this list is growing. Implementing support for a new ADO.NET provider is easily accomplished:
 

--- a/src/Syrx.Extensions/Syrx.Extensions.csproj
+++ b/src/Syrx.Extensions/Syrx.Extensions.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/todo.md
+++ b/todo.md
@@ -99,8 +99,8 @@ This document tracks outstanding tasks, improvements, and issues that need to be
 
 ### Version 3.0.0
 
-- [ ] **Complete migration to .NET 8.0**
-  - Ensure all packages target .NET 8.0
+- [x] **Complete migration to .NET 10.0**
+  - Ensure all packages target .NET 10.0
   - Update all dependencies to compatible versions
 
 - [ ] **Breaking changes documentation**
@@ -109,7 +109,7 @@ This document tracks outstanding tasks, improvements, and issues that need to be
 
 ### Future Versions
 
-- [ ] **Consider .NET 9.0 support**
+- [ ] **Monitor future .NET releases**
   - Evaluate new features that could benefit Syrx
   - Plan migration timeline
 


### PR DESCRIPTION
This pull request updates the Syrx project documentation and configuration to target .NET 10.0, replacing previous references to .NET 8.0 and 9.0. It also updates a key dependency and makes minor documentation improvements for clarity and accuracy.

.NET 10.0 migration and compatibility updates:
* Updated all documentation (`README.md`, `.docs/Syrx/readme.md`, `.docs/quick-start.md`, `.github/copilot-instructions.md`) to state that Syrx now targets .NET 10.0, removing references to earlier versions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L171-R171) [[2]](diffhunk://#diff-31e186ad8def4fb0fb1f2e22dac8b274f513091ad69f984e9cc74cd45253c2f0L162-R162) [[3]](diffhunk://#diff-2f11576685249bbdd186c87a12a6fb1a5c2303fd9505043b5c7e18bdd5851c37L17-R17) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L452-R452)
* Updated the `todo.md` to mark the migration to .NET 10.0 as complete and to reflect the new target version in future planning. [[1]](diffhunk://#diff-13432f2375977371d353bba0f2f76fa94385d5c4e247d3083b0b6e83d995be61L102-R103) [[2]](diffhunk://#diff-13432f2375977371d353bba0f2f76fa94385d5c4e247d3083b0b6e83d995be61L112-R112)

Dependency updates:
* Bumped `Microsoft.Extensions.DependencyInjection` package version from `10.0.1` to `10.0.4` in `src/Syrx.Extensions/Syrx.Extensions.csproj`.

Documentation improvements:
* Fixed a typo in `.docs/Syrx/readme.md` ("two swap out" → "to swap out").
* Clarified the use of `Func<>` in predicate composition in `.docs/Syrx/readme.md`.