### PR TITLE
improved doc comments

### DIFF
--- a/src/Syrx.Extensions/ServiceCollectionExtensions.cs
+++ b/src/Syrx.Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,13 @@ namespace Syrx.Extensions
 {
     public static class ServiceCollectionExtensions
     {
+        /// <summary>
+        /// Registers Syrx services in the <see cref="IServiceCollection"/> using the provided builder configuration.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to register Syrx services into.</param>
+        /// <param name="factory">A delegate used to configure the <see cref="SyrxBuilder"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/> for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="factory"/> is null.</exception>
         public static IServiceCollection UseSyrx(
             this IServiceCollection services,
             Action<SyrxBuilder> factory
@@ -25,6 +32,14 @@ namespace Syrx.Extensions
             return services;
         }
 
+        /// <summary>
+        /// Attempts to add a service descriptor to the <see cref="IServiceCollection"/> if the service type has not already been registered.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to register the service into.</param>
+        /// <param name="serviceType">The type of the service to register.</param>
+        /// <param name="implementationType">The implementation type to use for the service.</param>
+        /// <param name="lifetime">The <see cref="ServiceLifetime"/> for the service. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/> for chaining.</returns>
         public static IServiceCollection TryAddToServiceCollection(
             this IServiceCollection services,
             Type serviceType,
@@ -38,6 +53,13 @@ namespace Syrx.Extensions
                     lifetime));
         }
 
+        /// <summary>
+        /// Attempts to register a singleton service instance in the <see cref="IServiceCollection"/> if the service type has not already been registered.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to register the service into.</param>
+        /// <param name="serviceType">The type of the service to register.</param>
+        /// <param name="instance">The singleton instance to register.</param>
+        /// <returns>The <see cref="IServiceCollection"/> for chaining.</returns>
         public static IServiceCollection TryAddToServiceCollection(
             this IServiceCollection services,
             Type serviceType,

--- a/src/Syrx/ICommander.MultimapAsync.cs
+++ b/src/Syrx/ICommander.MultimapAsync.cs
@@ -16,11 +16,11 @@ namespace Syrx
         /// <summary>
         ///     Queries the data source asynchronously.
         /// </summary>
-        /// <typeparam name="TResult"></typeparam>        
+        /// <typeparam name="TResult">The type to map the query results to.</typeparam>
         /// <param name="parameters">The parameters to be passed to operation.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">The method.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<TResult>
             (object parameters = null,
             CancellationToken cancellationToken = default,
@@ -34,9 +34,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">Mapping predicate used to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, TResult>(Func<T1, T2, TResult> map,
             object parameters = null,
             CancellationToken cancellationToken = default,
@@ -51,9 +51,9 @@ namespace Syrx
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, TResult>(
             Func<T1, T2, T3, TResult> map,
             object parameters = null,
@@ -70,9 +70,9 @@ namespace Syrx
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, TResult>(
             Func<T1, T2, T3, T4, TResult> map,
             object parameters = null,
@@ -90,9 +90,9 @@ namespace Syrx
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, TResult>(
             Func<T1, T2, T3, T4, T5, TResult> map,
             object parameters = null, CancellationToken cancellationToken = default,
@@ -110,9 +110,9 @@ namespace Syrx
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, TResult>(
             Func<T1, T2, T3, T4, T5, T6, TResult> map,
             object parameters = null,
@@ -132,9 +132,9 @@ namespace Syrx
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, TResult> map,
             object parameters = null,

--- a/src/Syrx/ICommander.MultipleAsync.cs
+++ b/src/Syrx/ICommander.MultipleAsync.cs
@@ -20,9 +20,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<TResult>> map,
@@ -38,9 +38,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, TResult>(
             Func<IEnumerable<T1>,
                 IEnumerable<T2>,
@@ -58,9 +58,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -80,9 +80,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -104,9 +104,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -130,9 +130,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -158,9 +158,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -188,9 +188,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -220,9 +220,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -254,9 +254,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -290,9 +290,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -328,9 +328,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -368,9 +368,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -410,9 +410,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -454,9 +454,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,
@@ -500,9 +500,9 @@ namespace Syrx
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="map">The mapping predicate to use to compose the result type.</param>
         /// <param name="parameters">Optional parameters to pass to the query.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="method">Optionally pass a method name to use as the key to finding a command setting.</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation that returns a collection of TResult.</returns>
         Task<IEnumerable<TResult>> QueryAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(
             Func<IEnumerable<T1>,
                  IEnumerable<T2>,


### PR DESCRIPTION
This pull request improves the XML documentation for several public extension methods and interface methods related to service registration and asynchronous query operations. The updates provide clearer descriptions of parameters, return values, and exceptions, making the API easier to understand and use.

**Documentation improvements for service registration:**

* Added detailed XML documentation to `UseSyrx` and both overloads of `TryAddToServiceCollection` in `ServiceCollectionExtensions.cs`, specifying parameters, return values, and possible exceptions. [[1]](diffhunk://#diff-aefbd51a3a40457d4f9af14aec7407e2a112df0dd146226a1bbb741eb1446164R8-R14) [[2]](diffhunk://#diff-aefbd51a3a40457d4f9af14aec7407e2a112df0dd146226a1bbb741eb1446164R35-R42) [[3]](diffhunk://#diff-aefbd51a3a40457d4f9af14aec7407e2a112df0dd146226a1bbb741eb1446164R56-R62)

**Documentation improvements for asynchronous query methods:**

* Enhanced XML documentation for all `QueryAsync` overloads in `ICommander.MultimapAsync.cs` and `ICommander.MultipleAsync.cs`, clarifying type parameters, parameters (especially the `cancellationToken`), and return values. [[1]](diffhunk://#diff-72df34383dcd46b27ad8fd5e23eb294ff9c73b63f547d0a41616116ff059587fL19-R23) [[2]](diffhunk://#diff-72df34383dcd46b27ad8fd5e23eb294ff9c73b63f547d0a41616116ff059587fL37-R39) [[3]](diffhunk://#diff-72df34383dcd46b27ad8fd5e23eb294ff9c73b63f547d0a41616116ff059587fL54-R56) [[4]](diffhunk://#diff-72df34383dcd46b27ad8fd5e23eb294ff9c73b63f547d0a41616116ff059587fL73-R75) [[5]](diffhunk://#diff-72df34383dcd46b27ad8fd5e23eb294ff9c73b63f547d0a41616116ff059587fL93-R95) [[6]](diffhunk://#diff-72df34383dcd46b27ad8fd5e23eb294ff9c73b63f547d0a41616116ff059587fL113-R115) [[7]](diffhunk://#diff-72df34383dcd46b27ad8fd5e23eb294ff9c73b63f547d0a41616116ff059587fL135-R137) [[8]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL23-R25) [[9]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL41-R43) [[10]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL61-R63) [[11]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL83-R85) [[12]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL107-R109) [[13]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL133-R135) [[14]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL161-R163) [[15]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL191-R193) [[16]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL223-R225) [[17]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL257-R259) [[18]](diffhunk://#diff-6a2dfe4cc5078f29cf68186b780377c8230bdb0b7576a685e8d3d8b288f73a9eL293-R295)