### PR TITLE
Chore/upgrade workspace 20260525

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,10 @@ jobs:
         dotnet-version: [ '10.0.x' ]
         
     steps:    
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       name: Setup dotnet ${{ matrix.dotnet-version }}
      
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
           dotnet-version: ${{ matrix.dotnet-version }}
       # You can test your matrix by printing the current dotnet version
@@ -42,7 +42,7 @@ jobs:
     - run: dotnet build --configuration Release
 
     # Publish the NuGet package as an artifact, so they can be used in the following jobs
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: nuget
         if-no-files-found: error
@@ -55,10 +55,10 @@ jobs:
     steps:
       # Install the .NET SDK indicated in the global.json file
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
       # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}
@@ -66,9 +66,9 @@ jobs:
   run_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
     - name: Run tests
       run: dotnet test --configuration Release
 
@@ -81,14 +81,14 @@ jobs:
     needs: [ validate_nuget, run_test ]
     steps:
       # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}
 
       # Install the .NET SDK indicated in the global.json file
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
       # Publish all NuGet packages to NuGet.org
       # Use --skip-duplicate to prevent errors if a package with the same version already exists.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ on:
 env:
   NuGetDirectory: ${{ github.workspace }}/src/*/bin/Release/
 
+permissions: {}
+
 defaults:
   run:
     shell: pwsh
@@ -23,6 +25,8 @@ defaults:
 jobs:
   create_nuget:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         dotnet-version: [ '10.0.x' ]
@@ -52,6 +56,8 @@ jobs:
   validate_nuget:
     runs-on: ubuntu-latest
     needs: [ create_nuget ]
+    permissions:
+      contents: read
     steps:
       # Install the .NET SDK indicated in the global.json file
       - name: Setup .NET
@@ -65,6 +71,8 @@ jobs:
 
   run_test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup .NET
@@ -79,6 +87,8 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs: [ validate_nuget, run_test ]
+    permissions:
+      contents: read
     steps:
       # Download the NuGet package created in the previous job
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/publish.yml` to improve security and reliability by pinning action versions to specific commit SHAs and explicitly setting permissions for each job. These changes help prevent supply chain attacks and ensure workflow consistency.

**Security and reliability improvements:**

* All GitHub Actions (`actions/checkout`, `actions/setup-dotnet`, `actions/upload-artifact`, and `actions/download-artifact`) are now pinned to specific commit SHAs instead of floating version tags, reducing the risk of unexpected changes or compromised actions. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R19-R38) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L45-R49) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R59-R79) [[4]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R90-R101)
* Explicit `permissions` blocks with `contents: read` have been added to each workflow job, following GitHub's least-privilege best practices. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R19-R38) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R59-R79) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R90-R101)
* A top-level `permissions: {}` block has been added to the workflow file to override the default permissions and require explicit permission declarations for each job.